### PR TITLE
Prefix metrics, SQL, and catalog routes with /api

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -23,9 +23,9 @@ app.include_router(sensors.router, prefix="/api")
 app.include_router(placements.router, prefix="/api")
 app.include_router(thresholds.router, prefix="/api")
 app.include_router(timeseries.router, prefix="/api")
-app.include_router(metrics.router)
-app.include_router(sql.router)
-app.include_router(catalog.router)
+app.include_router(metrics.router, prefix="/api")
+app.include_router(sql.router, prefix="/api")
+app.include_router(catalog.router, prefix="/api")
 
 @app.get("/-/health")
 def health():


### PR DESCRIPTION
## Summary
- mount metrics, SQL, and catalog routers under `/api`

## Testing
- `pytest` (no tests ran)
- manual requests hitting `/api/metrics/overview`, `/api/sql/run`, and `/api/catalog/metrics` via TestClient

------
https://chatgpt.com/codex/tasks/task_e_68b1b10e49d0832fb323b0760cb372be