### PR TITLE
feat(web): add helper for form uploads

### DIFF
--- a/web/src/app/floorplans/upload/page.tsx
+++ b/web/src/app/floorplans/upload/page.tsx
@@ -1,6 +1,7 @@
 // web/src/app/floorplans/upload/page.tsx
 'use client'
 import { useState } from 'react'
+import { apiPostForm } from '@/lib/api'
 
 export default function UploadFloorplan() {
   const [siteId, setSiteId] = useState<number>(1)
@@ -14,12 +15,15 @@ export default function UploadFloorplan() {
     fd.append('site_id', String(siteId))
     fd.append('name', name || file.name)
     fd.append('file', file)
-    const r = await fetch(`${process.env.NEXT_PUBLIC_API_BASE || '/api'}/floorplans/upload`, {
-      method: 'POST', body: fd
-    })
-    if (!r.ok) return setMsg(`Falhou: ${await r.text()}`)
-    const data = await r.json()
-    setMsg(`OK! id=${data.id}`)
+    try {
+      const data = await apiPostForm<{ id: number }>(
+        '/floorplans/upload',
+        fd
+      )
+      setMsg(`OK! id=${data.id}`)
+    } catch (e: any) {
+      setMsg(`Falhou: ${e?.message ?? e}`)
+    }
   }
 
   return (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,6 +1,15 @@
 'use client'
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || '/api'
 
+function authHeaders(init?: RequestInit) {
+  const headers = new Headers(init?.headers)
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token')
+    if (token) headers.set('Authorization', `Bearer ${token}`)
+  }
+  return headers
+}
+
 async function handle(r: Response, method: string, path: string) {
   if (!r.ok) {
     const text = await r.text().catch(() => '')
@@ -10,21 +19,36 @@ async function handle(r: Response, method: string, path: string) {
 }
 
 export async function apiGet<T>(path: string, init?: RequestInit): Promise<T> {
+  const headers = authHeaders(init)
+  headers.set('Content-Type', 'application/json')
   const r = await fetch(`${API_BASE}${path}`, {
     ...init,
     method: 'GET',
-    headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+    headers,
     cache: 'no-store',
   })
   return handle(r, 'GET', path)
 }
 
 export async function apiPost<T>(path: string, body: unknown, init?: RequestInit): Promise<T> {
+  const headers = authHeaders(init)
+  headers.set('Content-Type', 'application/json')
   const r = await fetch(`${API_BASE}${path}`, {
     ...init,
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...(init?.headers || {}) },
+    headers,
     body: JSON.stringify(body),
+  })
+  return handle(r, 'POST', path)
+}
+
+export async function apiPostForm<T>(path: string, form: FormData, init?: RequestInit): Promise<T> {
+  const headers = authHeaders(init)
+  const r = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    method: 'POST',
+    headers,
+    body: form,
   })
   return handle(r, 'POST', path)
 }


### PR DESCRIPTION
## Summary
- add auth-aware API helper for form data posts
- use new helper for floorplan uploads

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)
- `npm install --save-exact --save-dev @types/react @types/node` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b1b1121c14832f8fd387ee9d87b242