### PR TITLE
fix: adjust database env var and api volume

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,9 +3,9 @@ services:
     build: ./api
     env_file: .env
     environment:
-      - DATABASE_URL=${DATABASE_URLS}
+      - DATABASE_URL=${DATABASE_URL}
     volumes:
-      - ./api/app:/app/ap
+      - ./api/app:/app/app
     ports:
       - "8000:8000"
     command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- use `DATABASE_URL` instead of `DATABASE_URLS`
- correct API service volume path to `/app/app`

## Testing
- `docker compose config` *(fails: command not found: docker)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b60bc870832f9cc7884c325d7bc5