### PR TITLE
feat: configure CORS origins via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Plataforma interna para visualizar sensores LoRaWAN ingeridos em PostgreSQL/Time
 3. `docker compose build && docker compose up -d`.
 4. Web: `http://<vm>`; API docs: `http://<vm>:8000/docs`.
 
+## CORS
+Defina uma lista de domínios confiáveis para a API usando a variável de ambiente `ALLOW_ORIGINS`. Os domínios devem ser separados por vírgula. Exemplo:
+
+```env
+ALLOW_ORIGINS=https://app.exemplo.com,https://outro.exemplo.org
+```
+
+Inclua essa linha em `.env` ou exporte a variável antes de iniciar o serviço.
+
 ## Notas
 - ETL transforma `raw.uplink.payload` → `ingest.measurement`.
 - CAGGs (5m/1h) e retenção (90d) para performance.

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -6,12 +6,14 @@ from .routes import catalog, sql, metrics, auth, sites, floorplans, devices, sen
 app = FastAPI(title="LoraMon API")
 
 
+origins = os.getenv("ALLOW_ORIGINS", "*")
+
 app.add_middleware(
- CORSMiddleware,
- allow_origins=["*"], # rede interna; ajuste depois
- allow_credentials=True,
- allow_methods=["*"],
- allow_headers=["*"],
+    CORSMiddleware,
+    allow_origins=[origin.strip() for origin in origins.split(",") if origin.strip()],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 


### PR DESCRIPTION
## Summary
- configure FastAPI CORS using `ALLOW_ORIGINS` environment variable
- document how to set allowed origins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b60d1c64832f82dba4411b69e15c