### PR TITLE
fix: align db env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Sample environment variables for LoraMon
-# Database connection URL passed to services (compose.yml maps DATABASE_URLS -> DATABASE_URL)
-DATABASE_URLS=postgresql://user:pass@db/loramon
+# Database connection URL passed to services
+# When PostgreSQL runs on the host, replace `db` with `host.docker.internal`
+DATABASE_URL=postgresql://user:pass@db/loramon
 # Connection string used by migrations/ETL scripts
 DATABASE_URL_SYNC=postgresql://user:pass@db/loramon
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Plataforma interna para visualizar sensores LoRaWAN ingeridos em PostgreSQL/TimescaleDB.
 
 ## Subir
-1. Copie `.env.example` para `.env` e ajuste credenciais do banco e `SECRET_KEY`.
+1. Copie `.env.example` para `.env` e ajuste `DATABASE_URL`, `DATABASE_URL_SYNC` e `SECRET_KEY`.
+   Se o PostgreSQL estiver rodando fora do Docker, utilize `host.docker.internal` como host em `DATABASE_URL`.
 2. Aplique migração: `psql "$DATABASE_URL_SYNC" -f db/migrations/001_init.sql`.
 3. `docker compose build && docker compose up -d`.
 4. Web: `http://<vm>`; API docs: `http://<vm>:8000/docs`.

--- a/api/app/database.py
+++ b/api/app/database.py
@@ -2,7 +2,7 @@ import os
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
 from sqlalchemy.orm import declarative_base
 
-DATABASE_URL = os.getenv("DATABASE_URL", "")
+DATABASE_URL = os.getenv("DATABASE_URL") or os.getenv("DATABASE_URLS", "")
 
 # garantir driver async
 if DATABASE_URL.startswith("postgresql://"):


### PR DESCRIPTION
## Summary
- align database env variable name
- document host.docker.internal for external PG
- accept legacy DATABASE_URLS

## Testing
- `poetry install --no-root`
- `poetry run pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: E403 Forbidden fetching @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bb79c564832f90b64d40f30c45c6