### PR TITLE
feat: add database health check endpoint

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,7 +1,15 @@
+import logging
 import os
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .deps import get_db
 from .routes import catalog, sql, metrics, auth, sites, floorplans, devices, sensors, placements, thresholds, timeseries
+
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="LoraMon API")
 
@@ -32,3 +40,23 @@ app.include_router(catalog.router, prefix="/api")
 @app.get("/-/health")
 def health():
  return {"ok": True}
+
+
+@app.get("/api/-/health/db")
+async def health_db(db: AsyncSession = Depends(get_db)):
+    """Verifica a conectividade com o banco de dados."""
+    try:
+        result = await db.execute(
+            text(
+                "SELECT current_database() AS database, current_user AS user, now() AS now"
+            )
+        )
+        row = result.mappings().one()
+        return {
+            "database": row["database"],
+            "user": row["user"],
+            "now": row["now"].isoformat(),
+        }
+    except Exception as exc:  # pragma: no cover - log unexpected errors
+        logger.exception("Database health check failed")
+        raise HTTPException(status_code=503, detail="Database connection error") from exc


### PR DESCRIPTION
## Summary
- add database connectivity health endpoint
- log DB connectivity errors and return 503 response

## Testing
- `pytest -q` *(fails: Connect call failed ('::1', 5432))*


------
https://chatgpt.com/codex/tasks/task_e_68b200f36190832f87ace60582958e6b