### PR TITLE
feat: support enabled flag for metric mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ Execute a migração com:
 psql "$DATABASE_URL_SYNC" -f db/migrations/001_init.sql
 ```
 
+Para atualizar um banco existente criado antes desta versão, aplique a migração incremental:
+
+```bash
+psql "$DATABASE_URL_SYNC" -f db/migrations/002_metric_map_device_profile_enabled.sql
+```
+
+### Atualização manual de bancos existentes
+
+Alternativamente, você pode executar diretamente os comandos:
+
+```sql
+ALTER TABLE app.metric_map RENAME COLUMN device_prof TO device_profile;
+ALTER TABLE app.metric_map ADD COLUMN enabled boolean NOT NULL DEFAULT true;
+```
+
 ## API
 
 A API é implementada em FastAPI e inclui middleware de CORS configurável via `ALLOW_ORIGINS`. Autenticação usa JWT (`/api/auth/login`). As principais rotas incluem:

--- a/db/migrations/001_init.sql
+++ b/db/migrations/001_init.sql
@@ -93,10 +93,11 @@ ON CONFLICT DO NOTHING;
 CREATE TABLE IF NOT EXISTS app.metric_map (
  id bigserial PRIMARY KEY,
  application text NULL,
- device_prof text NULL,
+ device_profile text NULL,
  json_path text NOT NULL, -- ex.: '{object,decoded,temperature}'
  metric text NOT NULL, -- ex.: 'temperature_C'
- unit text NOT NULL -- ex.: '°C'
+ unit text NOT NULL, -- ex.: '°C'
+ enabled boolean NOT NULL DEFAULT true
 );
 
 -- RBAC e metadados do app

--- a/db/migrations/002_metric_map_device_profile_enabled.sql
+++ b/db/migrations/002_metric_map_device_profile_enabled.sql
@@ -1,0 +1,7 @@
+-- Rename device_prof to device_profile and add enabled flag to metric_map
+ALTER TABLE app.metric_map
+  RENAME COLUMN device_prof TO device_profile;
+
+ALTER TABLE app.metric_map
+  ADD COLUMN enabled boolean NOT NULL DEFAULT true;
+


### PR DESCRIPTION
## Summary
- add migration to rename device_prof to device_profile and add enabled flag
- reflect new columns in initial SQL setup
- document metric_map migration steps

## Testing
- `pytest` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68b200f71428832fabb84c501d27a231