### PR TITLE
api: make overview.last_update windowed

### DIFF
--- a/api/app/routes/metrics.py
+++ b/api/app/routes/metrics.py
@@ -13,20 +13,28 @@ async def overview(
     db: AsyncSession = Depends(get_db),
 ):
     # evita :mins::interval – usa multiplicação por interval
-    q = text("""
+    q = text(
+        """
         WITH w AS (
           SELECT now() - (:mins * interval '1 minute') AS t0
         )
         SELECT
+          -- sensores ativos na janela
           (SELECT COUNT(DISTINCT sensor_id)
              FROM ingest.measurement
             WHERE "time" >= (SELECT t0 FROM w)
-          )                               AS sensors_ativos,
-          (SELECT COALESCE(MAX("time"), now())
+          ) AS sensors_ativos,
+
+          -- última atualização NA MESMA JANELA
+          (SELECT COALESCE(MAX("time"), (SELECT t0 FROM w))
              FROM ingest.measurement
-          )                               AS ultima_atualizacao,
+            WHERE "time" >= (SELECT t0 FROM w)
+          ) AS ultima_atualizacao,
+
+          -- total de alertas
           (SELECT COUNT(*) FROM app.sensor_threshold) AS total_alertas_config
-    """)
+    """
+    )
     row = (await db.execute(q, {"mins": minutes})).mappings().one()
     last_update = row["ultima_atualizacao"]
     return {
@@ -48,7 +56,8 @@ async def series(
     db: AsyncSession = Depends(get_db),
 ):
     # nota: usa "time" e device_id corretos, sem CAST com ::
-    q = text("""
+    q = text(
+        """
         SELECT
           FLOOR(EXTRACT(EPOCH FROM m."time") / :step) * :step AS bucket,
           AVG(m.value)                                       AS value
@@ -58,11 +67,17 @@ async def series(
           AND m."time"  >= now() - (:mins * interval '1 minute')
         GROUP BY 1
         ORDER BY 1
-    """)
-    rows = (await db.execute(q, {
-        "device": device,
-        "metric": metric,
-        "mins": minutes,
-        "step": step,
-    })).all()
+    """
+    )
+    rows = (
+        await db.execute(
+            q,
+            {
+                "device": device,
+                "metric": metric,
+                "mins": minutes,
+                "step": step,
+            },
+        )
+    ).all()
     return [{"ts": int(b), "value": v} for (b, v) in rows]


### PR DESCRIPTION
## Summary
- align metrics overview's `ultima_atualizacao` with the requested window, matching `sensors_ativos`

## Testing
- ⚠️ `docker compose build api` (command not found: docker)
- ⚠️ `docker compose up -d api` (command not found: docker)
- ⚠️ `docker compose exec api curl -s "http://localhost:8000/api/metrics/overview?minutes=60"` (command not found: docker)
- ⚠️ `docker compose exec db psql -U postgres -d databridge -c "SELECT now() AS db_now, (SELECT MAX(time) FROM ingest.measurement) AS max_all, (SELECT MAX(time) FROM ingest.measurement WHERE time >= now() - interval '60 minute') AS max_60m;"` (command not found: docker)
- ⚠️ `docker compose restart api` (command not found: docker)
- ❌ `pytest` (database connection failed)


------
https://chatgpt.com/codex/tasks/task_e_68b20d119080832f87ddde4b5df48c9d