### PR TITLE
Instrument ETL pipeline with detailed logging and dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A variável `SECRET_KEY` define a chave usada para assinar os tokens e `ACCESS_T
 
 ## ETL
 
-O script `etl/etl.py` utiliza `DATABASE_URL_SYNC` para conexão síncrona. Ele lê lotes de `raw.uplink`, extrai métricas numéricas do JSON, atualiza `ingest.measurement` e mantém um checkpoint em `ingest.etl_checkpoint`. As variáveis `ETL_BATCH` (tamanho do lote) e `ETL_SLEEP` (intervalo de polling) permitem ajustes finos.
+O script `etl/etl.py` utiliza `DATABASE_URL_SYNC` para conexão síncrona. Ele lê lotes de `raw.uplink`, extrai métricas numéricas do JSON, atualiza `ingest.measurement` e mantém um checkpoint em `ingest.etl_checkpoint`. As variáveis `ETL_BATCH` (tamanho do lote) e `ETL_SLEEP` (intervalo de polling) permitem ajustes finos. Consulte `etl/README.md` para detalhes sobre o formato de `json_path` e para usar o modo de diagnóstico com `python etl.py --once --limit 20 --verbose`.
 
 ## Frontend Web
 

--- a/etl/README.md
+++ b/etl/README.md
@@ -1,0 +1,26 @@
+# ETL
+
+Script que converte registros de `raw.uplink` em pontos na tabela `ingest.measurement`.
+
+## `json_path`
+
+Cada linha de `app.metric_map` define `metric` e um `json_path` que aponta
+para o valor dentro do payload JSON. O caminho é separado por vírgulas e
+suporta índices de arrays utilizando números. Exemplos:
+
+- `{object,internal_sensors_temperature}`
+- `{rxInfo,0,rssi}`  – acessa o primeiro elemento do array `rxInfo` e o campo `rssi`.
+
+Se `label` não for informado na `metric_map`, o nome da própria métrica será
+usado como `sensor_id` na inserção.
+
+## Dry-run
+
+Para diagnosticar mapeamentos execute:
+
+```bash
+python etl.py --once --limit 20 --verbose
+```
+
+O comando acima busca os últimos 20 uplinks e imprime uma tabela com
+`metric -> json_path -> valor` (ou `MISSING`). Nenhum dado é gravado no banco.

--- a/etl/test_parse_payload.py
+++ b/etl/test_parse_payload.py
@@ -1,0 +1,42 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "etl_module", Path(__file__).resolve().parent / "etl.py"
+)
+etl = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(etl)  # type: ignore
+parse_payload = etl.parse_payload
+
+
+def test_parse_payload_with_arrays():
+    payload = {
+        "object": {"internal_sensors_temperature": 22.5},
+        "rxInfo": [{"rssi": -70, "snr": 5}, {"rssi": -72}],
+    }
+    mapping = [
+        {
+            "json_path": "{object,internal_sensors_temperature}",
+            "metric": "object_internal_sensors_temperature",
+            "unit": "°C",
+        },
+        {"json_path": "{rxInfo,0,rssi}", "metric": "rxInfo_0_rssi", "unit": "dBm"},
+    ]
+
+    metrics, fails = parse_payload(payload, mapping)
+    assert not fails
+    assert (
+        "object_internal_sensors_temperature",
+        22.5,
+        "°C",
+        "object_internal_sensors_temperature",
+    ) in metrics
+    assert (
+        "rxInfo_0_rssi",
+        -70.0,
+        "dBm",
+        "rxInfo_0_rssi",
+    ) in metrics


### PR DESCRIPTION
## Summary
- add array-aware json path extraction with failure logging
- provide dry-run mode and CLI for inspecting uplinks
- document json_path format and diagnostic usage

## Testing
- `python -m pytest etl/test_parse_payload.py -q`
- `python -m py_compile etl/etl.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2123fd868832f9fc9bbefb30df1af